### PR TITLE
Update available

### DIFF
--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionLine.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionLine.java
@@ -8,6 +8,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
 import org.controlsfx.glyphfont.FontAwesome;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,11 @@ class ExtensionLine extends HBox {
     @FXML
     private Label name;
     @FXML
-    private Tooltip tooltip;
+    private Tooltip descriptionTooltip;
+    @FXML
+    private Label updateAvailable;
+    @FXML
+    private Region separator;
     @FXML
     private Button add;
     @FXML
@@ -101,7 +106,12 @@ class ExtensionLine extends HBox {
             }
         });
 
-        tooltip.setText(extension.description());
+        descriptionTooltip.setText(extension.description());
+        Tooltip.install(separator, name.getTooltip());
+
+        updateAvailable.setVisible(true); //TODO: change
+        //TODO: add tooltip
+        updateAvailable.managedProperty().bind(updateAvailable.visibleProperty());
 
         add.setGraphic(UiUtils.getFontAwesomeIcon(FontAwesome.Glyph.PLUS_CIRCLE));
         settings.setGraphic(UiUtils.getFontAwesomeIcon(FontAwesome.Glyph.GEAR));

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
@@ -5,12 +5,15 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
 
 <fx:root alignment="CENTER_LEFT" spacing="5.0" styleClass="row" type="HBox" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
-   <Label fx:id="name" maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS">
+   <Label fx:id="name">
       <tooltip>
-         <Tooltip fx:id="tooltip" />
+         <Tooltip fx:id="descriptionTooltip" />
       </tooltip></Label>
+   <Label fx:id="updateAvailable" styleClass="warn-text" text="%Catalog.ExtensionLine.updateAvailable" />
+   <Region fx:id="separator" HBox.hgrow="ALWAYS" />
    <Button fx:id="add" contentDisplay="GRAPHIC_ONLY" layoutX="10.0" layoutY="10.0" mnemonicParsing="false" onAction="#onAddClicked">
       <tooltip>
          <Tooltip text="%Catalog.ExtensionLine.installExtension" />

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
@@ -12,7 +12,10 @@
       <tooltip>
          <Tooltip fx:id="descriptionTooltip" />
       </tooltip></Label>
-   <Label fx:id="updateAvailable" styleClass="warn-text" text="%Catalog.ExtensionLine.updateAvailable" />
+   <Label fx:id="updateAvailable" styleClass="warn-text" text="%Catalog.ExtensionLine.updateAvailable">
+      <tooltip>
+         <Tooltip fx:id="updateAvailableTooltip" />
+      </tooltip></Label>
    <Region fx:id="separator" HBox.hgrow="ALWAYS" />
    <Button fx:id="add" contentDisplay="GRAPHIC_ONLY" layoutX="10.0" layoutY="10.0" mnemonicParsing="false" onAction="#onAddClicked">
       <tooltip>

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
@@ -50,6 +50,7 @@ Catalog.ExtensionDetails.browserError = Browser error
 Catalog.ExtensionDetails.cannotOpen = Cannot open "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (update available)
+Catalog.ExtensionLine.updateAvailableDetails = A new version ({0}) is available
 Catalog.ExtensionLine.installExtension = Install extension
 Catalog.ExtensionLine.updateExtension = Update extension
 Catalog.ExtensionLine.removeExtension = Remove extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
@@ -49,6 +49,7 @@ Catalog.ExtensionDetails.close = Close
 Catalog.ExtensionDetails.browserError = Browser error
 Catalog.ExtensionDetails.cannotOpen = Cannot open "{0}":\n{1}
 
+Catalog.ExtensionLine.updateAvailable = (update available)
 Catalog.ExtensionLine.installExtension = Install extension
 Catalog.ExtensionLine.updateExtension = Update extension
 Catalog.ExtensionLine.removeExtension = Remove extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
@@ -50,6 +50,7 @@ Catalog.ExtensionDetails.browserError = Erreur de navigateur
 Catalog.ExtensionDetails.cannotOpen = Impossible d'ouvrir "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (mise à jour disponible)
+Catalog.ExtensionLine.updateAvailableDetails = Une nouvelle version ({0}) est disponible
 Catalog.ExtensionLine.installExtension = Installer l'extension
 Catalog.ExtensionLine.updateExtension = Mettre à jour l'extension
 Catalog.ExtensionLine.removeExtension = Supprimer l'extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
@@ -49,6 +49,7 @@ Catalog.ExtensionDetails.close = Fermer
 Catalog.ExtensionDetails.browserError = Erreur de navigateur
 Catalog.ExtensionDetails.cannotOpen = Impossible d'ouvrir "{0}":\n{1}
 
+Catalog.ExtensionLine.updateAvailable = (mise à jour disponible)
 Catalog.ExtensionLine.installExtension = Installer l'extension
 Catalog.ExtensionLine.updateExtension = Mettre à jour l'extension
 Catalog.ExtensionLine.removeExtension = Supprimer l'extension


### PR DESCRIPTION
When an extension is installed with a version that is not the latest, a message (and a tooltip) indicates that a new version is available.

<img width="803" alt="image" src="https://github.com/user-attachments/assets/96208eee-8a17-45d1-a6bf-e73a10d46346" />

You don't have to review the code, but you can make comments on whether it should look different / if we need something else to indicate that an update is available.