### PR TITLE
Javadoc urls typo

### DIFF
--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
@@ -594,7 +594,7 @@ public class ExtensionCatalogManager implements AutoCloseable{
                 )
         ));
 
-        for (URI javadocUri: release.get().javadocsUrls()) {
+        for (URI javadocUri: release.get().javadocUrls()) {
             downloadUrlToFilePaths.add(new UriFileName(
                     javadocUri,
                     Paths.get(

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/Release.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/Release.java
@@ -15,7 +15,7 @@ import java.util.List;
  *                               This list is immutable and won't be null
  * @param optionalDependencyUrls SciJava Maven, Maven Central, or GitHub URLs where optional dependency jars can be downloaded.
  *                               This list is immutable and won't be null
- * @param javadocsUrls SciJava Maven, Maven Central, or GitHub URLs where javadoc jars for the main extension
+ * @param javadocUrls SciJava Maven, Maven Central, or GitHub URLs where javadoc jars for the main extension
  *                     jar and for dependencies can be downloaded. This list is immutable and won't be null
  * @param versionRange a specification of minimum and maximum compatible versions
  */
@@ -24,7 +24,7 @@ public record Release(
         URI mainUrl,
         List<URI> requiredDependencyUrls,
         List<URI> optionalDependencyUrls,
-        List<URI> javadocsUrls,
+        List<URI> javadocUrls,
         VersionRange versionRange
 ) {
     private static final List<String> VALID_HOSTS = List.of("github.com", "maven.scijava.org", "repo1.maven.org");
@@ -50,8 +50,8 @@ public record Release(
      *                               Can be null
      * @param optionalDependencyUrls SciJava Maven, Maven Central, or GitHub URLs where optional dependency jars can be downloaded.
      *                               Can be null
-     * @param javadocsUrls SciJava Maven, Maven Central, or GitHub URLs where javadoc jars for the main extension
-     *                     jar and for dependencies can be downloaded. Can be null
+     * @param javadocUrls SciJava Maven, Maven Central, or GitHub URLs where javadoc jars for the main extension
+     *                    jar and for dependencies can be downloaded. Can be null
      * @param versionRange a specification of minimum and maximum compatible versions
      * @throws IllegalArgumentException when the created release is not valid (see the requirements above)
      */
@@ -60,14 +60,14 @@ public record Release(
             URI mainUrl,
             List<URI> requiredDependencyUrls,
             List<URI> optionalDependencyUrls,
-            List<URI> javadocsUrls,
+            List<URI> javadocUrls,
             VersionRange versionRange
     ) {
         this.name = name;
         this.mainUrl = mainUrl;
         this.requiredDependencyUrls = requiredDependencyUrls == null ? List.of() : Collections.unmodifiableList(requiredDependencyUrls);
         this.optionalDependencyUrls = optionalDependencyUrls == null ? List.of() : Collections.unmodifiableList(optionalDependencyUrls);
-        this.javadocsUrls = javadocsUrls == null ? List.of() : Collections.unmodifiableList(javadocsUrls);
+        this.javadocUrls = javadocUrls == null ? List.of() : Collections.unmodifiableList(javadocUrls);
         this.versionRange = versionRange;
 
         checkValidity();
@@ -84,7 +84,7 @@ public record Release(
 
         checkURIHostValidity(requiredDependencyUrls);
         checkURIHostValidity(optionalDependencyUrls);
-        checkURIHostValidity(javadocsUrls);
+        checkURIHostValidity(javadocUrls);
     }
 
     private static void checkURIHostValidity(List<URI> uris) {

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestCatalog.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestCatalog.java
@@ -66,7 +66,19 @@ public class TestCatalog {
 
         @Test
         void Check_Valid_Catalog() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            Catalog expectedCatalog = new Catalog(
+                    "",
+                    "",
+                    List.of(new Extension(
+                            "",
+                            "",
+                            "",
+                            URI.create("https://github.com/qupath/qupath"),
+                            List.of()
+                    ))
+            );
+
+            Catalog catalog = new Gson().fromJson("""
                     {
                         "name": "",
                         "description": "",
@@ -82,7 +94,9 @@ public class TestCatalog {
                     }
                     """,
                     Catalog.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedCatalog, catalog);
         }
 
         @Test

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestExtension.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestExtension.java
@@ -157,7 +157,22 @@ public class TestExtension {
 
         @Test
         void Check_Valid_Extension() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            Extension expectedExtension = new Extension(
+                    "",
+                    "",
+                    "",
+                    URI.create("https://github.com/qupath/qupath"),
+                    List.of(new Release(
+                            "v1.0.0",
+                            URI.create("https://github.com/qupath/qupath"),
+                            null,
+                            null,
+                            null,
+                            new VersionRange("v1.0.0", null, null)
+                    ))
+            );
+
+            Extension extension = new Gson().fromJson("""
                     {
                         "name": "",
                         "description": "",
@@ -175,7 +190,9 @@ public class TestExtension {
                     }
                     """,
                     Extension.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedExtension, extension);
         }
 
         @Test

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestRelease.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestRelease.java
@@ -193,7 +193,16 @@ public class TestRelease {
 
         @Test
         void Check_Valid_Release() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            Release expectedRelease = new Release(
+                    "v0.1.0",
+                    URI.create("https://github.com/qupath/qupath"),
+                    null,
+                    null,
+                    null,
+                    new VersionRange("v1.0.0", null, null)
+            );
+
+            Release release = new Gson().fromJson("""
                     {
                         "name": "v0.1.0",
                         "mainUrl": "https://github.com/qupath/qupath",
@@ -204,7 +213,9 @@ public class TestRelease {
                     """
                     ,
                     Release.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedRelease, release);
         }
 
         @Test
@@ -310,7 +321,9 @@ public class TestRelease {
 
         @Test
         void Check_Valid_Required_Dependency_Url() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            List<URI> expectedRequiredDependencyUrls = List.of(URI.create("https://maven.scijava.org/content"));
+
+            Release release = new Gson().fromJson("""
                     {
                         "name": "v0.1.0",
                         "mainUrl": "https://github.com/qupath/qupath",
@@ -322,7 +335,9 @@ public class TestRelease {
                     """
                     ,
                     Release.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedRequiredDependencyUrls, release.requiredDependencyUrls());
         }
 
         @Test
@@ -346,7 +361,9 @@ public class TestRelease {
 
         @Test
         void Check_Valid_Optional_Dependency_Url() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            List<URI> expectedOptionalDependencyUrls = List.of(URI.create("https://maven.scijava.org/content"));
+
+            Release release = new Gson().fromJson("""
                     {
                         "name": "v0.1.0",
                         "mainUrl": "https://github.com/qupath/qupath",
@@ -358,7 +375,9 @@ public class TestRelease {
                     """
                     ,
                     Release.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedOptionalDependencyUrls, release.optionalDependencyUrls());
         }
 
         @Test
@@ -382,11 +401,13 @@ public class TestRelease {
 
         @Test
         void Check_Valid_Javadoc_Url() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            List<URI> expectedJavadocUrls = List.of(URI.create("https://maven.scijava.org/content"));
+
+            Release release = new Gson().fromJson("""
                     {
                         "name": "v0.1.0",
                         "mainUrl": "https://github.com/qupath/qupath",
-                        "javadocsUrls": ["https://maven.scijava.org/content"],
+                        "javadocUrls": ["https://maven.scijava.org/content"],
                         "versionRange": {
                             "min": "v1.0.0"
                         }
@@ -394,7 +415,9 @@ public class TestRelease {
                     """
                     ,
                     Release.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedJavadocUrls, release.javadocUrls());
         }
 
         @Test
@@ -405,7 +428,7 @@ public class TestRelease {
                             {
                                 "name": "v0.1.0",
                                 "mainUrl": "https://github.com/qupath/qupath/",
-                                "javadocsUrls": ["https://qupath.readthedocs.io/"],
+                                "javadocUrls": ["https://qupath.readthedocs.io/"],
                                 "versionRange": {
                                     "min": "v1.0.0"
                                 }

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestVersionRange.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestVersionRange.java
@@ -129,13 +129,17 @@ public class TestVersionRange {
 
         @Test
         void Check_Valid_Version_Range() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+            VersionRange expectedVersionRange = new VersionRange("v1.1.0", null, null);
+
+            VersionRange versionRange = new Gson().fromJson("""
                     {
                         "min": "v1.1.0"
                     }
                     """,
                     VersionRange.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedVersionRange, versionRange);
         }
 
         @Test
@@ -151,15 +155,19 @@ public class TestVersionRange {
         }
 
         @Test
-        void Check_Valid_With_Max() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+        void Check_Max() {
+            String expectedMax = "v2.0.0";
+
+            VersionRange versionRange = new Gson().fromJson("""
                     {
                         "min": "v1.1.0",
                         "max": "v2.0.0"
                     }
                     """,
                     VersionRange.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedMax, versionRange.max());
         }
 
         @Test
@@ -178,15 +186,19 @@ public class TestVersionRange {
         }
 
         @Test
-        void Check_Valid_With_Excluded() {
-            Assertions.assertDoesNotThrow(() -> new Gson().fromJson("""
+        void Check_Excluded() {
+            List<String> expectedExcluded = List.of("v1.3.0", "v2.0.0");
+
+            VersionRange versionRange = new Gson().fromJson("""
                     {
                         "min": "v1.1.0",
                         "excludes": ["v1.3.0", "v2.0.0"]
                     }
                     """,
                     VersionRange.class
-            ));
+            );
+
+            Assertions.assertEquals(expectedExcluded, versionRange.excludes());
         }
 
         @Test


### PR DESCRIPTION
Change `javadocsUrls` to `javadocUrls`.

Add stronger tests to detect such issues.