### PR TITLE
UI and version changes

### DIFF
--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
@@ -102,7 +102,7 @@ public class ExtensionCatalogManager implements AutoCloseable{
             String version,
             Registry defaultRegistry
     ) {
-        Version.isValid(version);
+        Version.isValid(version, true);
 
         this.extensionFolderManager = new ExtensionFolderManager(extensionDirectoryPath);
         this.extensionClassLoader = new ExtensionClassLoader(parentClassLoader);

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/Release.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/Release.java
@@ -78,7 +78,7 @@ public record Release(
         Utils.checkField(mainUrl, "mainUrl", "Release");
         Utils.checkField(versionRange, "versionRange", "Release");
 
-        Version.isValid(name);
+        Version.isValid(name, true);
 
         Utils.checkGithubURI(mainUrl);
 

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/VersionRange.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/catalog/VersionRange.java
@@ -8,9 +8,8 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A specification of the minimum and maximum versions that an extension supports. Versions should be specified in the
- * form "v[MAJOR].[MINOR].[PATCH]" corresponding to semantic versions, although trailing release candidate qualifiers
- * (eg, "-rc1") are also allowed.
+ * A specification of the minimum and maximum versions that an extension supports. Versions should follow the
+ * specifications of {@link Version}.
  *
  * @param min the minimum/lowest version that this extension is known to be compatible with
  * @param max the maximum/highest version that this extension is known to be compatible with. Can be null
@@ -95,7 +94,7 @@ public record VersionRange(String min, String max, List<String> excludes) {
     private void checkValidity() {
         Utils.checkField(min, "min", "VersionRange");
 
-        Version.isValid(min);
+        Version.isValid(min, false);
 
         if (max != null) {
             if (new Version(min).compareTo(new Version(max)) > 0) {

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionLine.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionLine.java
@@ -6,6 +6,7 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
@@ -49,7 +50,7 @@ class ExtensionLine extends HBox {
     @FXML
     private Tooltip descriptionTooltip;
     @FXML
-    private Label updateAvailable;
+    private Hyperlink updateAvailable;
     @FXML
     private Tooltip updateAvailableTooltip;
     @FXML
@@ -181,6 +182,11 @@ class ExtensionLine extends HBox {
         );
 
         infoTooltip.setText(String.format("%s\n%s", extension.description(), extension.homepage()));
+    }
+
+    @FXML
+    private void onUpdateAvailableClicked(ActionEvent ignored) {
+        onSettingsClicked(ignored);
     }
 
     @FXML

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
@@ -59,6 +59,8 @@ class ExtensionModificationWindow extends Stage {
     @FXML
     private Label name;
     @FXML
+    private Label currentVersion;
+    @FXML
     private ChoiceBox<Release> release;
     @FXML
     private CheckBox optionalDependencies;
@@ -115,6 +117,16 @@ class ExtensionModificationWindow extends Stage {
 
         name.setText(extension.name());
 
+        if (installedExtension == null) {
+            currentVersion.setVisible(false);
+            currentVersion.setManaged(false);
+        } else {
+            currentVersion.setText(MessageFormat.format(
+                    resources.getString("Catalog.ExtensionModificationWindow.currentVersion"),
+                    installedExtension.releaseName()
+            ));
+        }
+
         release.getItems().addAll(extension.releases().stream()
                 .filter(release -> release.versionRange().isCompatible(extensionCatalogManager.getVersion()))
                 .toList()
@@ -130,13 +142,7 @@ class ExtensionModificationWindow extends Stage {
                 return null;
             }
         });
-        release.getSelectionModel().select(installedExtension == null ?
-                release.getItems().isEmpty() ? null : release.getItems().getFirst() :
-                release.getItems().stream()
-                        .filter(release -> release.name().equals(installedExtension.releaseName()))
-                        .findAny()
-                        .orElse(release.getItems().isEmpty() ? null : release.getItems().getFirst())
-        );
+        release.getSelectionModel().select(release.getItems().isEmpty() ? null : release.getItems().getFirst());
 
         optionalDependencies.visibleProperty().bind(release.getSelectionModel()
                 .selectedItemProperty()

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_line.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
@@ -12,10 +13,11 @@
       <tooltip>
          <Tooltip fx:id="descriptionTooltip" />
       </tooltip></Label>
-   <Label fx:id="updateAvailable" styleClass="warn-text" text="%Catalog.ExtensionLine.updateAvailable">
+   <Hyperlink fx:id="updateAvailable" onAction="#onUpdateAvailableClicked" styleClass="warn-text" text="%Catalog.ExtensionLine.updateAvailable">
       <tooltip>
          <Tooltip fx:id="updateAvailableTooltip" />
-      </tooltip></Label>
+      </tooltip>
+   </Hyperlink>
    <Region fx:id="separator" HBox.hgrow="ALWAYS" />
    <Button fx:id="add" contentDisplay="GRAPHIC_ONLY" layoutX="10.0" layoutY="10.0" mnemonicParsing="false" onAction="#onAddClicked">
       <tooltip>

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_modification_window.fxml
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_modification_window.fxml
@@ -25,8 +25,9 @@
                         <Font name="System Bold" size="13.0" />
                     </font>
                 </Label>
+            <Label fx:id="currentVersion" />
                 <HBox alignment="CENTER" spacing="10.0">
-                    <Label text="%Catalog.ExtensionModificationWindow.version" />
+                    <Label text="%Catalog.ExtensionModificationWindow.versionToInstall" />
                     <ChoiceBox fx:id="release" prefWidth="150.0" />
                <VBox.margin>
                   <Insets left="20.0" right="20.0" />
@@ -40,9 +41,8 @@
                     <TextArea fx:id="filesToDownload" editable="false" prefHeight="100.0" />
                 </VBox>
                 <VBox fx:id="replaceDirectory">
-                    <Label fx:id="replaceDirectoryLabel" maxWidth="1.7976931348623157E308" minHeight="-Infinity"
-                           styleClass="warn-text" wrapText="true"/>
-                    <Hyperlink fx:id="replaceDirectoryLink" onAction="#onReplacedDirectoryClicked"/>
+                    <Label fx:id="replaceDirectoryLabel" maxWidth="1.7976931348623157E308" minHeight="-Infinity" styleClass="warn-text" wrapText="true" />
+                    <Hyperlink fx:id="replaceDirectoryLink" onAction="#onReplacedDirectoryClicked" />
                 </VBox>
                 <HBox alignment="CENTER">
                     <Button fx:id="submit" mnemonicParsing="false" onAction="#onSubmitClicked" />

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
@@ -59,12 +59,13 @@ Catalog.ExtensionLine.removed = {0} removed.
 Catalog.ExtensionLine.error = Error
 Catalog.ExtensionLine.cannotDeleteExtension = Cannot delete extension:\n{0}
 
-Catalog.ExtensionModificationWindow.version = Version:
+Catalog.ExtensionModificationWindow.versionToInstall = Version to install:
 Catalog.ExtensionModificationWindow.installOptionalDependencies = Install optional dependencies
 Catalog.ExtensionModificationWindow.replaceDirectory = This will replace the following directory and all of its content:
 Catalog.ExtensionModificationWindow.extensionDirectoryNotRetrieved = Impossible to retrieve the extension directory. Was its path correctly defined?
 Catalog.ExtensionModificationWindow.installExtension = Install extension
 Catalog.ExtensionModificationWindow.editExtension = Edit extension
+Catalog.ExtensionModificationWindow.currentVersion = Current version: {0}
 Catalog.ExtensionModificationWindow.followingFilesDownloaded = The following files will be downloaded:
 Catalog.ExtensionModificationWindow.cannotRetrieveLinks = Impossible to retrieve download links.
 Catalog.ExtensionModificationWindow.install = Install

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
@@ -59,12 +59,13 @@ Catalog.ExtensionLine.removed = {0} supprimée.
 Catalog.ExtensionLine.error = Erreur
 Catalog.ExtensionLine.cannotDeleteExtension = Impossible de supprimer l'extension:\n{0}
 
-Catalog.ExtensionModificationWindow.version = Version:
+Catalog.ExtensionModificationWindow.versionToInstall = Version à installer:
 Catalog.ExtensionModificationWindow.installOptionalDependencies = Installer les dépendances facultatives
 Catalog.ExtensionModificationWindow.replaceDirectory = Cela remplacera le dossier suivant et tout son contenu:
 Catalog.ExtensionModificationWindow.extensionDirectoryNotRetrieved = Impossible de récupérer le dossier contenant l'extension. Son chemin a-t-il été correctement défini ?
 Catalog.ExtensionModificationWindow.installExtension = Installer l'extension
 Catalog.ExtensionModificationWindow.editExtension = Modifier l'extension
+Catalog.ExtensionModificationWindow.currentVersion = Version actuelle : {0}
 Catalog.ExtensionModificationWindow.followingFilesDownloaded = Les fichiers suivants seront téléchargés:
 Catalog.ExtensionModificationWindow.cannotRetrieveLinks = Impossible de récupérer les liens de téléchargement.
 Catalog.ExtensionModificationWindow.install = Installer

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/TestVersion.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/TestVersion.java
@@ -30,12 +30,22 @@ public class TestVersion {
     }
 
     @Test
-    void Check_Valid_Version() {
+    void Check_Version_Without_Patch() {
+        Assertions.assertDoesNotThrow(() -> new Version("v1.2"));
+    }
+
+    @Test
+    void Check_Version_Without_Patch_And_Minor() {
+        Assertions.assertDoesNotThrow(() -> new Version("v1"));
+    }
+
+    @Test
+    void Check_Fully_Specified_Version() {
         Assertions.assertDoesNotThrow(() -> new Version("v1.2.3"));
     }
 
     @Test
-    void Check_Valid_Version_With_Release_Candidate() {
+    void Check_Fully_Specified_Version_With_Release_Candidate() {
         Assertions.assertDoesNotThrow(() -> new Version("v1.2.3-rc4"));
     }
 
@@ -78,6 +88,26 @@ public class TestVersion {
     void Check_Version_Inequality_With_Same_Major_Minor_And_Patch() {
         Version lowerVersion = new Version("v1.2.4");
         Version upperVersion = new Version("v1.2.4");
+
+        int comparison = lowerVersion.compareTo(upperVersion);
+
+        Assertions.assertEquals(0, comparison);
+    }
+
+    @Test
+    void Check_Version_Inequality_With_No_Patch() {
+        Version lowerVersion = new Version("v1.2.4");
+        Version upperVersion = new Version("v1.2");
+
+        int comparison = lowerVersion.compareTo(upperVersion);
+
+        Assertions.assertEquals(0, comparison);
+    }
+
+    @Test
+    void Check_Version_Inequality_With_No_Patch_And_Minor() {
+        Version lowerVersion = new Version("v1.2.4");
+        Version upperVersion = new Version("v1");
 
         int comparison = lowerVersion.compareTo(upperVersion);
 

--- a/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestVersionRange.java
+++ b/extensionmanager/src/test/java/qupath/ext/extensionmanager/core/catalog/TestVersionRange.java
@@ -321,6 +321,62 @@ public class TestVersionRange {
     }
 
     @Test
+    void Check_Compatible_Version_When_Minor_Not_Specified_For_Min() {
+        VersionRange versionRange = new VersionRange(
+                "v0.1",
+                "v1.0.0",
+                List.of("v0.1.1", "v0.2.0", "v1.0.0")
+        );
+        String version = "v0.1.4";
+
+        boolean isCompatible = versionRange.isCompatible(version);
+
+        Assertions.assertTrue(isCompatible);
+    }
+
+    @Test
+    void Check_Compatible_Version_When_Minor_And_Patch_Not_Specified_For_Min() {
+        VersionRange versionRange = new VersionRange(
+                "v0",
+                "v1.0.0",
+                List.of("v0.1.1", "v0.2.0", "v1.0.0")
+        );
+        String version = "v0.1.4";
+
+        boolean isCompatible = versionRange.isCompatible(version);
+
+        Assertions.assertTrue(isCompatible);
+    }
+
+    @Test
+    void Check_Compatible_Version_When_Minor_Not_Specified_For_Max() {
+        VersionRange versionRange = new VersionRange(
+                "v0.1.0",
+                "v1.0",
+                List.of("v0.1.1", "v0.2.0", "v1.0.0")
+        );
+        String version = "v1.0.4";
+
+        boolean isCompatible = versionRange.isCompatible(version);
+
+        Assertions.assertTrue(isCompatible);
+    }
+
+    @Test
+    void Check_Compatible_Version_When_Minor_And_Patch_Not_Specified_For_Max() {
+        VersionRange versionRange = new VersionRange(
+                "v0.1.0",
+                "v1",
+                List.of("v0.1.1", "v0.2.0", "v1.0.0")
+        );
+        String version = "v1.1.4";
+
+        boolean isCompatible = versionRange.isCompatible(version);
+
+        Assertions.assertTrue(isCompatible);
+    }
+
+    @Test
     void Check_Incompatible_Version_Because_Of_Min() {
         VersionRange versionRange = new VersionRange(
                 "v0.1.0",


### PR DESCRIPTION
* Allow versions not to have minor or patch numbers. For example, versions `v1.0` or `v1` are now accepted. `v1.0` refers to all version of the form `v1.0.x`, and `v1` refers to all versions of the form `v1.x.y`. This means for example that if a version range is specified with `min=v1.1` and `max=v3`, then `v1.1.4` is accepted, as well as `v3.5.7` for example (but not `v1.0.0` or `v4.0.0`).
* The `(update available)` orange text is now clickable and opens up the extension modification window.
* In the extension modification window, a line display the currently installed version. When this window is open, the highest installable extension is automatically selected.
![image](https://github.com/user-attachments/assets/d0522593-bb0f-4721-b6fb-74f4b85ff0df)