### PR TITLE
More elegant handling of cancellation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,1 +1,1 @@
-version = "1.0.0-rc4"
+version = "1.0.0-rc5"

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
@@ -388,11 +388,17 @@ public class ExtensionCatalogManager implements AutoCloseable{
             extensionProperty.set(Optional.empty());
         }
 
-        downloadAndExtractLinks(
-                getDownloadUrlsToFilePaths(savedCatalog, extension, installationInformation, true),
-                onProgress,
-                onStatusChanged
-        );
+        try {
+            downloadAndExtractLinks(
+                    getDownloadUrlsToFilePaths(savedCatalog, extension, installationInformation, true),
+                    onProgress,
+                    onStatusChanged
+            );
+        } catch (Exception e) {
+            logger.debug("Installation of {} failed. Clearing extension files", extension);
+            extensionFolderManager.deleteExtension(savedCatalog, extension);
+            throw e;
+        }
 
         synchronized (this) {
             extensionProperty.set(Optional.of(installationInformation));

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionCatalogManager.java
@@ -287,7 +287,7 @@ public class ExtensionCatalogManager implements AutoCloseable{
                 try {
                     extensionFolderManager.deleteExtensionsFromCatalog(savedCatalog);
                 } catch (IOException | SecurityException | InvalidPathException | NullPointerException e) {
-                    logger.debug(String.format("Could not delete %s", savedCatalog.name()), e);
+                    logger.debug("Could not delete {}", savedCatalog.name(), e);
                 }
             }
 
@@ -395,7 +395,7 @@ public class ExtensionCatalogManager implements AutoCloseable{
                     onStatusChanged
             );
         } catch (Exception e) {
-            logger.debug("Installation of {} failed. Clearing extension files", extension);
+            logger.debug("Installation of {} failed. Clearing extension files", extension.name());
             extensionFolderManager.deleteExtension(savedCatalog, extension);
             throw e;
         }
@@ -538,10 +538,7 @@ public class ExtensionCatalogManager implements AutoCloseable{
                     catalogExtension.extension
             );
         } catch (IOException | InvalidPathException | SecurityException | NullPointerException e) {
-            logger.debug(
-                    String.format("Error while retrieving %s installation information", catalogExtension.extension.name()),
-                    e
-            );
+            logger.debug("Error while retrieving {} installation information", catalogExtension.extension.name(), e);
             return Optional.empty();
         }
     }

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/FileDownloader.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/FileDownloader.java
@@ -41,7 +41,8 @@ public class FileDownloader {
      *                   will be a float between 0 and 1 indicating the progress of the download (0: beginning,
      *                   1: finished). This function will be called from the calling thread
      * @throws NullPointerException if one of the provided parameter is null
-     * @throws IOException if an I/O error occurs when sending the request or receiving the file
+     * @throws IOException if an I/O error occurs when sending the request or receiving the file. It can also occur
+     * when this function is interrupted, in which case its {@link Exception#getCause() cause} will be an {@link InterruptedException}
      * @throws InterruptedException if this function is interrupted
      * @throws IllegalArgumentException if the provided URI does not contain a valid scheme ("http" or "https")
      * @throws java.io.FileNotFoundException if the downloaded file already exists but is a directory rather than a regular

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/FileDownloader.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/FileDownloader.java
@@ -141,7 +141,8 @@ public class FileDownloader {
                     "The {} header {} cannot be converted to a number. Cannot indicate progress of {} download",
                     CONTENT_LENGTH_ATTRIBUTE,
                     contentLengthText,
-                    response.uri()
+                    response.uri(),
+                    e
             );
             return OptionalInt.empty();
         }

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/RecursiveDirectoryWatcher.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/tools/RecursiveDirectoryWatcher.java
@@ -132,7 +132,7 @@ class RecursiveDirectoryWatcher implements AutoCloseable {
                                 onFileDeleted.accept(filePath);
                                 addedFiles.remove(filePath);
                             } else {
-                                logger.debug("Unexpected event: {}", kind);
+                                logger.debug("Unexpected event {} with file {}. Ignoring it", kind, filePath);
                             }
                         } else {
                             logger.debug("The file or directory {} doesn't match the predicate, so it won't be reported", filePath);

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/CatalogManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/CatalogManager.java
@@ -341,7 +341,7 @@ class CatalogManager extends Stage {
                     deleteExtensions
             );
         } catch (IOException | SecurityException | NullPointerException e) {
-            logger.error("Error when removing {}", catalogsToDelete, e);
+            logger.error("Error when removing {}", catalogsToDelete.stream().map(SavedCatalog::name).toList(), e);
 
             displayErrorMessage(
                     resources.getString("CatalogManager.deleteCatalog"),

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
@@ -299,9 +299,9 @@ class ExtensionModificationWindow extends Stage {
                 Platform.runLater(progressWindow::close);
 
                 if (e instanceof InterruptedException || e.getCause() instanceof InterruptedException) {
-                    logger.debug("Installation of {} interrupted", extension, e);
+                    logger.debug("Installation of {} interrupted", extension.name(), e);
                 } else {
-                    logger.error("Error while installing {}", extension, e);
+                    logger.error("Error while installing {}", extension.name(), e);
 
                     Platform.runLater(() -> Dialogs.showErrorMessage(
                             resources.getString("Catalog.ExtensionModificationWindow.installationError"),

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionModificationWindow.java
@@ -296,11 +296,14 @@ class ExtensionModificationWindow extends Stage {
                     close();
                 });
             } catch (Exception e) {
-                logger.error("Error while installing extension", e);
+                Platform.runLater(progressWindow::close);
 
-                Platform.runLater(() -> {
-                    progressWindow.close();
-                    Dialogs.showErrorMessage(
+                if (e instanceof InterruptedException || e.getCause() instanceof InterruptedException) {
+                    logger.debug("Installation of {} interrupted", extension, e);
+                } else {
+                    logger.error("Error while installing {}", extension, e);
+
+                    Platform.runLater(() -> Dialogs.showErrorMessage(
                             resources.getString("Catalog.ExtensionModificationWindow.installationError"),
                             MessageFormat.format(
                                     resources.getString("Catalog.ExtensionModificationWindow.notInstalled"),
@@ -308,8 +311,8 @@ class ExtensionModificationWindow extends Stage {
                                     release.getSelectionModel().getSelectedItem().name(),
                                     e.getLocalizedMessage()
                             )
-                    );
-                });
+                    ));
+                }
             }
         });
         executor.shutdown();


### PR DESCRIPTION
Fix #15 by:

* Not showing any error window if the user cancels an extension installation. It is still logged with the `DEBUG` log level.
* Deleting all extension files if the extension installation fails.

If you cancel an extension installation and directly after install it again, you might still see a "Extension already installed" dialog. This is because this dialog pops up if the extension directory watcher detects a similar JAR, and the extension directory watcher can take a second to detect changes.