### PR TITLE
Inform user when no release available

### DIFF
--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/ExtensionManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/ExtensionManager.java
@@ -204,7 +204,7 @@ public class ExtensionManager extends Stage {
         }
 
         UiUtils.openFolderInFileExplorer(extensionDirectory).exceptionally(error -> {
-            logger.error("Error while opening QuPath extension directory {}", extensionDirectory, error);
+            logger.error("Error while opening extension directory {}", extensionDirectory, error);
 
             Dialogs.showErrorMessage(
                     resources.getString("ExtensionManager.error"),

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionDetails.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionDetails.java
@@ -29,6 +29,8 @@ class ExtensionDetails extends Stage {
     private Label description;
     @FXML
     private Hyperlink homepage;
+    @FXML
+    private Label notCompatible;
 
     /**
      * Create the window.
@@ -45,14 +47,12 @@ class ExtensionDetails extends Stage {
 
         setTitle(extension.name());
 
-        String descriptionText = extension.description();
-        if (noAvailableRelease) {
-            descriptionText += "\n";
-            descriptionText += resources.getString("Catalog.ExtensionDetails.extensionNotCompatible");
-        }
-        description.setText(descriptionText);
+        description.setText(extension.description());
 
         homepage.setText(extension.homepage().toString());
+
+        notCompatible.setVisible(noAvailableRelease);
+        notCompatible.setManaged(notCompatible.isVisible());
     }
 
     @FXML

--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionDetails.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/gui/catalog/ExtensionDetails.java
@@ -34,16 +34,24 @@ class ExtensionDetails extends Stage {
      * Create the window.
      *
      * @param extension the extension whose information should be displayed
+     * @param noAvailableRelease whether no release of this extension can be installed
      * @throws IOException when an error occurs while creating the container
      */
-    public ExtensionDetails(Extension extension) throws IOException {
+    public ExtensionDetails(Extension extension, boolean noAvailableRelease) throws IOException {
         UiUtils.loadFXML(this, ExtensionDetails.class.getResource("extension_details.fxml"));
 
         FXUtils.addCloseWindowShortcuts(this);
         initModality(Modality.WINDOW_MODAL);
 
         setTitle(extension.name());
-        description.setText(extension.description());
+
+        String descriptionText = extension.description();
+        if (noAvailableRelease) {
+            descriptionText += "\n";
+            descriptionText += resources.getString("Catalog.ExtensionDetails.extensionNotCompatible");
+        }
+        description.setText(descriptionText);
+
         homepage.setText(extension.homepage().toString());
     }
 

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_details.fxml
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/gui/catalog/extension_details.fxml
@@ -10,13 +10,14 @@
 
 <fx:root resizable="false" type="Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
    <scene>
-      <Scene>
+      <Scene stylesheets="@../styles.css">
          <VBox alignment="CENTER" spacing="5.0">
             <padding>
                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
             </padding>
             <Label fx:id="description" wrapText="true" />
             <Hyperlink fx:id="homepage" onAction="#onHomepageClicked" />
+            <Label fx:id="notCompatible" styleClass="warn-text" text="%Catalog.ExtensionDetails.extensionNotCompatible" />
             <Button mnemonicParsing="false" onAction="#onCloseClicked" text="%Catalog.ExtensionDetails.close" />
          </VBox>
       </Scene>

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
@@ -44,13 +44,13 @@ ManuallyInstalledExtensionLine.cannotDeleteExtension = Cannot delete extension:\
 ProgressWindow.cancel = Cancel
 
 Catalog.ExtensionDetails.close = Close
-Catalog.ExtensionDetails.extensionNotCompatible = This extension is not compatible with this version.
+Catalog.ExtensionDetails.extensionNotCompatible = This extension is not compatible with the current version of the software.
 Catalog.ExtensionDetails.browserError = Browser error
 Catalog.ExtensionDetails.cannotOpen = Cannot open "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (update available)
 Catalog.ExtensionLine.starredExtension = This extension is recommended by its authors as relevant for many users.
-Catalog.ExtensionLine.extensionNotCompatible = This extension is not compatible with this version.
+Catalog.ExtensionLine.extensionNotCompatible = This extension is not compatible with the current version of the software.
 Catalog.ExtensionLine.updateAvailableDetails = A new version ({0}) is available
 Catalog.ExtensionLine.installExtension = Install extension
 Catalog.ExtensionLine.updateExtension = Update extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings.properties
@@ -44,11 +44,13 @@ ManuallyInstalledExtensionLine.cannotDeleteExtension = Cannot delete extension:\
 ProgressWindow.cancel = Cancel
 
 Catalog.ExtensionDetails.close = Close
+Catalog.ExtensionDetails.extensionNotCompatible = This extension is not compatible with this version.
 Catalog.ExtensionDetails.browserError = Browser error
 Catalog.ExtensionDetails.cannotOpen = Cannot open "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (update available)
 Catalog.ExtensionLine.starredExtension = This extension is recommended by its authors as relevant for many users.
+Catalog.ExtensionLine.extensionNotCompatible = This extension is not compatible with this version.
 Catalog.ExtensionLine.updateAvailableDetails = A new version ({0}) is available
 Catalog.ExtensionLine.installExtension = Install extension
 Catalog.ExtensionLine.updateExtension = Update extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
@@ -44,11 +44,13 @@ ManuallyInstalledExtensionLine.cannotDeleteExtension = Impossible de supprimer l
 ProgressWindow.cancel = Annuler
 
 Catalog.ExtensionDetails.close = Fermer
+Catalog.ExtensionDetails.extensionNotCompatible = Cette extension n'est pas compatible avec cette version.
 Catalog.ExtensionDetails.browserError = Erreur de navigateur
 Catalog.ExtensionDetails.cannotOpen = Impossible d'ouvrir "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (mise à jour disponible)
 Catalog.ExtensionLine.starredExtension = Cette extension est recommandée par ses auteurs comme pertinente pour de nombreux utilisateurs.
+Catalog.ExtensionLine.extensionNotCompatible = Cette extension n'est pas compatible avec cette version.
 Catalog.ExtensionLine.updateAvailableDetails = Une nouvelle version ({0}) est disponible
 Catalog.ExtensionLine.installExtension = Installer l'extension
 Catalog.ExtensionLine.updateExtension = Mettre à jour l'extension

--- a/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
+++ b/extensionmanager/src/main/resources/qupath/ext/extensionmanager/strings_fr.properties
@@ -44,13 +44,13 @@ ManuallyInstalledExtensionLine.cannotDeleteExtension = Impossible de supprimer l
 ProgressWindow.cancel = Annuler
 
 Catalog.ExtensionDetails.close = Fermer
-Catalog.ExtensionDetails.extensionNotCompatible = Cette extension n'est pas compatible avec cette version.
+Catalog.ExtensionDetails.extensionNotCompatible = Cette extension n'est pas compatible avec la version actuelle du logiciel.
 Catalog.ExtensionDetails.browserError = Erreur de navigateur
 Catalog.ExtensionDetails.cannotOpen = Impossible d'ouvrir "{0}":\n{1}
 
 Catalog.ExtensionLine.updateAvailable = (mise à jour disponible)
 Catalog.ExtensionLine.starredExtension = Cette extension est recommandée par ses auteurs comme pertinente pour de nombreux utilisateurs.
-Catalog.ExtensionLine.extensionNotCompatible = Cette extension n'est pas compatible avec cette version.
+Catalog.ExtensionLine.extensionNotCompatible = Cette extension n'est pas compatible avec la version actuelle du logiciel.
 Catalog.ExtensionLine.updateAvailableDetails = Une nouvelle version ({0}) est disponible
 Catalog.ExtensionLine.installExtension = Installer l'extension
 Catalog.ExtensionLine.updateExtension = Mettre à jour l'extension


### PR DESCRIPTION
When no release of an extension can be installed:

* Add a message on the extension tooltip:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/763e6815-cf7e-4d3d-90dc-40a921b18962" />

* Add a message on the information window:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/8cf77995-5af8-4f90-9343-715e0ec4e80f" />
