### PR TITLE
Small adjustements

### DIFF
--- a/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionFolderManager.java
+++ b/extensionmanager/src/main/java/qupath/ext/extensionmanager/core/ExtensionFolderManager.java
@@ -1,6 +1,7 @@
 package qupath.ext.extensionmanager.core;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
@@ -68,7 +69,7 @@ class ExtensionFolderManager implements AutoCloseable {
     private static final String CATALOGS_FOLDER = "catalogs";
     private static final String REGISTRY_NAME = "registry.json";
     private static final Predicate<Path> isJar = path -> path.toString().toLowerCase().endsWith(".jar");
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private final ObservableValue<Path> extensionsDirectoryPath;
     private final ObservableValue<Path> catalogsDirectoryPath;
     private final FilesWatcher manuallyInstalledExtensionsWatcher;


### PR DESCRIPTION
* Save `registry.json` with the pretty print format.
* When an instance of `ExtensionCatalogManager` is created, warn if an extension is supposed to be installed (as indicated by `registry.json`) but no jar file is actually detected.